### PR TITLE
[#SD-568] Fix drag and drop on progress bar

### DIFF
--- a/src/javascripts/progress_bar.coffee
+++ b/src/javascripts/progress_bar.coffee
@@ -164,12 +164,12 @@ class ProgressBar extends Extension
         @player.setCurrentTime(newTime)
 
   handleDrag: (event) =>
-    position = Utils.calculateCursorPosition(event, @elem[0])
+    position = Utils.calculateCursorPosition(event, @railElement[0])
     if position <= @barWidth()
       @playedElement.width(position + 'px')
 
   handleDrop: (event) =>
-    position = Utils.calculateCursorPosition(event, @elem[0])
+    position = Utils.calculateCursorPosition(event, @railElement[0])
 
     # catch drop positions outside of progress bar
     position = 0.001 if position < 0


### PR DESCRIPTION
The prodigee player code was written with the assumption that the progress bar will always start at the edge of the whole player. Their original CSS removes the time-played component from the progress bar layout by giving it position absolute so their code works for them 🤦.

![Screen Shot 2020-10-30 at 12 45 25](https://user-images.githubusercontent.com/7852553/97701565-eb0b9000-1aad-11eb-8dbe-ed250d5bae41.png)


But when we restyled the player and kept the time-played component positioned within the progress bar, that caused a bug with drag and dropping the progress bar, note the bar is ~40px to the right of the cursor instead at the cursor:

![2020-10-30 11 30 47](https://user-images.githubusercontent.com/7852553/97701250-66b90d00-1aad-11eb-9730-4e138843215c.gif)

The fix is to change the element used to calculate the left offset. Instead calculating from `@elem[0]` which is the whole progress bar including time-played, we need to use `@railElement[0]` which is just the thin long rectangle.